### PR TITLE
Fix small issue in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,7 @@ gst_apps_install: gst_apps
 	@echo "Install Gst Apps"
 	cd $(GST_APPS_PATH); \
 	mkdir -p $(INSTALL_PATH)/opt/edgeai-gst-apps-pc; \
-	cp -r $(GST_APPS_PATH)/* $(INSTALL_PATH)/opt/edgeai-gst-apps-pc/
+	cp -r * $(INSTALL_PATH)/opt/edgeai-gst-apps-pc/
 
 gst_apps_clean:
 	@echo "Clean Gst Apps"


### PR DESCRIPTION
The "Install Gst Apps" target in the Makefile switches to GST_APPS_PATH and then tries to immediately copy out of the GST_APPS_PATH/*, which will always fail.

This small patch removes the doubling (clipboard error?)